### PR TITLE
Change to `python >=3.10` in the .toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.0.post1"
+version = "0.1.1"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}
@@ -13,7 +13,7 @@ maintainers = [
     {name = "GitHub: m-misiura"}
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 dependencies = [
     "llama-stack",


### PR DESCRIPTION
There is a need to relax the 3.12 requirement for the provider

## Summary by Sourcery

Relax supported Python versions and increment package version

Enhancements:
- Relax Python requirement from >=3.12 to >=3.10

Chores:
- Bump package version to 0.1.1