### PR TITLE
:memo: changing python version to 3.12 or above

### DIFF
--- a/.github/workflows/publish-2-pypi.yaml
+++ b/.github/workflows/publish-2-pypi.yaml
@@ -17,7 +17,7 @@ jobs:
       
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'  # Speed up builds
       
       - run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.2"
+version = "0.1.3"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}
@@ -13,7 +13,7 @@ maintainers = [
     {name = "GitHub: m-misiura"}
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
     "llama-stack",


### PR DESCRIPTION
There is a need to upgrade python to 3.12 based on this change https://github.com/meta-llama/llama-stack/pull/2475

## Summary by Sourcery

Bump package version to 0.1.3 and update the minimum Python requirement to 3.12

Enhancements:
- Increase Python requirement to >=3.12

Chores:
- Update package version to 0.1.3