### PR TITLE
feat: add health check 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.3"
+version = "0.1.4"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}


### PR DESCRIPTION
Based on previous discussions, it seems like a good idea to add a health check for the `FMS Orchestrator URL` during the startup of the `DetectorProvider`. If the orchestrator is unreachable or misconfigured, the provider enters a degraded mode and logs clear warnings.

Workflow is:
- on provider initialisation, we attempt to contact the orchestrator’s /health endpoint (or the main URL as fallback).
- if the orchestrator is reachable, we startup proceeds as normal; if not, we log a warning and set the provider to degraded mode.

When in degraded mode, the distro still starts up, but with a set of instructions for remediation

e.g. 
```
INFO     2025-07-04 16:37:57,709 llama_stack.distribution.distribution:183 core: Successfully loaded external provider remote::trustyai_fms           
ERROR    2025-07-04 16:37:57,738 llama_stack_provider_trustyai_fms.detectors.base:1033 uncategorized: Connection error to orchestrator health endpoint
         at https://lol/health: HTTPSConnectionPool(host='lol', port=443): Max retries exceeded with url: /health (Caused by                          
         NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x1086f4260>: Failed to resolve 'lol' ([Errno 8] nodename nor servname    
         provided, or not known)"))                                                                                                                   
ERROR    2025-07-04 16:37:57,741 llama_stack_provider_trustyai_fms.detectors.base:1033 uncategorized: Connection error to orchestrator main endpoint  
         at https://lol: HTTPSConnectionPool(host='lol', port=443): Max retries exceeded with url: / (Caused by                                       
         NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x1086f54f0>: Failed to resolve 'lol' ([Errno 8] nodename nor servname    
         provided, or not known)"))                                                                                                                   
WARNING  2025-07-04 16:37:57,742 llama_stack_provider_trustyai_fms.detectors.base:1037 uncategorized: ⚠️  Cannot reach FMS Orchestrator at https://lol.
         Safety operations will be disabled until the service is available.                                                                           
         🚨 SAFETY PROVIDER STARTED IN DEGRADED MODE 🚨                                                                                               
         Safety operations are DISABLED until orchestrator is properly configured.                                                                    
         To enable safety features:                                                                                                                   
         1. Set FMS_ORCHESTRATOR_URL to your FMS Orchestrator service URL                                                                             
         2. Ensure the orchestrator service is running and accessible                                                                                 
         3. Restart this service                                           
```

## Summary by Sourcery

Add startup health checks for the FMS Orchestrator in DetectorProvider, enter a degraded mode with warnings if unreachable or misconfigured, skip safety initialization in degraded mode, and bump the package version.

New Features:
- Add synchronous health check for FMS Orchestrator URL on DetectorProvider initialization
- Introduce degraded mode with clear warnings when the orchestrator is unreachable or misconfigured

Enhancements:
- Skip full provider initialization when in degraded mode to disable safety operations

Build:
- Bump package version to 0.1.4