### PR TITLE
:construction: added tls support

### DIFF
--- a/llama_stack_provider_trustyai_fms/detectors/base.py
+++ b/llama_stack_provider_trustyai_fms/detectors/base.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
-
 import httpx
 
 from llama_stack.apis.inference import (
@@ -31,6 +30,9 @@ from llama_stack.apis.shields import ListShieldsResponse, Shield, Shields
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 from ..config import (
     BaseDetectorConfig,
+    ContentDetectorConfig,
+    ChatDetectorConfig,
+    DetectorParams,
     EndpointType,
 )
 
@@ -164,12 +166,25 @@ class BaseDetector(Safety, ShieldsProtocolPrivate, ABC):
     async def initialize(self) -> None:
         """Initialize detector resources"""
         logger.info(f"Initializing {self.__class__.__name__}")
+        
+        # Get SSL configuration from config
+        ssl_config = {}
+        if hasattr(self.config, 'get_ssl_config'):
+            ssl_config = self.config.get_ssl_config()
+        
+         # Add debug logging here
+        logger.debug(f"[DEBUG] SSL config for {self.config.detector_id}: {ssl_config}")
+        logger.debug(f"[DEBUG] ssl_cert_path: {getattr(self.config, 'ssl_cert_path', None)}")
+        logger.debug(f"[DEBUG] verify_ssl: {getattr(self.config, 'verify_ssl', None)}")
+
+        # Create HTTP client with SSL configuration
         self._http_client = httpx.AsyncClient(
             timeout=self.config.request_timeout,
             limits=httpx.Limits(
                 max_keepalive_connections=self.config.max_keepalive_connections,
                 max_connections=self.config.max_connections,
             ),
+            **ssl_config  # Apply SSL configuration here
         )
 
     async def shutdown(self) -> None:
@@ -298,7 +313,11 @@ class BaseDetector(Safety, ShieldsProtocolPrivate, ABC):
         if not self.config.use_orchestrator_api and self.config.detector_id:
             headers["detector-id"] = self.config.detector_id
 
-        if self.config.auth_token:
+        # Use the new get_auth_headers method from config
+        if hasattr(self.config, 'get_auth_headers'):
+            auth_headers = self.config.get_auth_headers()
+            headers.update(auth_headers)
+        elif self.config.auth_token:
             headers["Authorization"] = f"Bearer {self.config.auth_token}"
 
         return headers
@@ -832,10 +851,6 @@ class SimpleShieldStore(ShieldStore):
         self, shield_id: str, params: Dict[str, Any]
     ) -> None:
         """Create a dynamic shield configuration from API parameters"""
-        from ..config import ContentDetectorConfig, ChatDetectorConfig, DetectorParams
-
-        logger.info(f"Creating dynamic shield configuration for: {shield_id}")
-
         # Extract shield configuration from API params
         shield_type = params.get("type", "content")
         confidence_threshold = params.get("confidence_threshold", 0.5)
@@ -871,6 +886,10 @@ class SimpleShieldStore(ShieldStore):
                 orchestrator_url=orchestrator_url,
                 detector_url=None,  # Will be set if needed
                 auth_token=None,
+                verify_ssl=params.get("verify_ssl", True),
+                ssl_cert_path=params.get("ssl_cert_path"),
+                ssl_client_cert=params.get("ssl_client_cert"),
+                ssl_client_key=params.get("ssl_client_key"),
             )
         elif shield_type == "chat":
             config = ChatDetectorConfig(
@@ -889,6 +908,10 @@ class SimpleShieldStore(ShieldStore):
                 orchestrator_url=orchestrator_url,
                 detector_url=None,
                 auth_token=None,
+                verify_ssl=params.get("verify_ssl", True),
+                ssl_cert_path=params.get("ssl_cert_path"),
+                ssl_client_cert=params.get("ssl_client_cert"),
+                ssl_client_key=params.get("ssl_client_key"),
             )
         else:
             raise DetectorValidationError(f"Unknown shield type: {shield_type}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.3"
+version = "0.1.4"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}


### PR DESCRIPTION
## Description

It is important for the provider http client to be able to handle requests to secure routes of the guardrails orchestrator; consequently this PR add tls support 

Note that this PR should be merged before [PR #9](https://github.com/trustyai-explainability/llama-stack-provider-trustyai-fms/pull/9) as it contains important feature to the provider http client

## Test plan

On openshift, follow these steps in this README(https://github.com/m-misiura/llama-stack-k8s/tree/tls-testing); this outlines how to: 

0. deploy hap and local detectors together with the orchestrator
1. deploy llama stack distribution with [a custom image](https://quay.io/repository/rh-ee-mmisiura/lls/manifest/sha256:2a80be6ee40f72c08ac0b8ca6dd782afd329b104b536ed32a8df92cfc4e9c977) pointing to the test.pypi version of the [provider package](https://test.pypi.org/project/llama-stack-provider-trustyai-fms/)
2. mounting the relevant certificates to the llama-stack distribution pod
3. registering a secure shield and testing the shield via POST requests

## Summary by Sourcery

Add TLS/SSL support and authentication handling to the provider HTTP client by introducing new config options and helper methods, applying them to HTTPX clients and shield creation, and bumping the package version.

New Features:
- Introduce TLS configuration in BaseDetectorConfig, enabling verify flag, CA cert path, and client cert/key for secure HTTP requests
- Add auth_token field and get_auth_headers method for injecting bearer tokens into HTTP request headers
- Extend FMSSafetyProviderConfig and dynamic shield creation to propagate SSL and auth settings from provider to shields

Enhancements:
- Apply SSL options to httpx.AsyncClient initialization and add debug logging of SSL config in detector startup

Build:
- Bump package version to 0.1.4