### PR TITLE
feat: address LLS PR #2637 and add means of configuring provider via module

### DIFF
--- a/llama_stack_provider_trustyai_fms/detectors/base.py
+++ b/llama_stack_provider_trustyai_fms/detectors/base.py
@@ -676,7 +676,7 @@ class SimpleShieldStore(ShieldStore):
         self._initialized = False
         self._lock = asyncio.Lock()  # Add lock
         logger.info(f"Created SimpleShieldStore: {self._store_id}")
-
+        
     async def register_detector_config(self, detector_id: str, config: Any) -> None:
         """Register detector configuration"""
         async with self._lock:
@@ -1008,7 +1008,11 @@ class DetectorProvider(Safety, Shields):
         if not value:
             logger.warning(f"Provider {self._provider_id} received null shield store")
             return
-
+        if hasattr(self, "_shield_store") and self._shield_store is not None:
+            logger.info(
+                f"Provider {self._provider_id} shield store already set (id: {id(self._shield_store)}), ignoring attempt to overwrite with id: {id(value)}"
+            )
+            return
         logger.info(
             f"Provider {self._provider_id} setting new shield store: {id(value)}"
         )

--- a/llama_stack_provider_trustyai_fms/provider.py
+++ b/llama_stack_provider_trustyai_fms/provider.py
@@ -16,7 +16,7 @@ def get_provider_spec() -> ProviderSpec:
         api=Api.safety,
         adapter=AdapterSpec(
             adapter_type="trustyai_fms",
-            config_class="config.FMSSafetyProviderConfig",
+            config_class="llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig",
             module="llama_stack_provider_trustyai_fms",
         ),
     )
@@ -27,7 +27,7 @@ def get_shields_provider_spec() -> ProviderSpec:
         api=Api.shields,
         adapter=AdapterSpec(
             adapter_type="trustyai_fms",
-            config_class="config.FMSSafetyProviderConfig",
+            config_class="llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig",
             module="llama_stack_provider_trustyai_fms",
         ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.4"
+version = "0.1.5"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    "llama-stack",
+    "llama-stack>=0.2.5",
     "fastapi",
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.1.5"
+version = "0.2.0"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    "llama-stack>=0.2.5",
+    "llama-stack>=0.2.14",
     "fastapi",
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -13,7 +13,7 @@ class TestProviderFunctions:
         assert spec.api == Api.safety
         assert isinstance(spec.adapter, AdapterSpec)
         assert spec.adapter.adapter_type == "trustyai_fms"
-        assert spec.adapter.config_class == "config.FMSSafetyProviderConfig"
+        assert spec.adapter.config_class == "llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig"
         assert spec.adapter.module == "llama_stack_provider_trustyai_fms"
 
     def test_get_shields_provider_spec(self):
@@ -23,5 +23,5 @@ class TestProviderFunctions:
         assert spec.api == Api.shields
         assert isinstance(spec.adapter, AdapterSpec)
         assert spec.adapter.adapter_type == "trustyai_fms"
-        assert spec.adapter.config_class == "config.FMSSafetyProviderConfig"
+        assert spec.adapter.config_class == "llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig"
         assert spec.adapter.module == "llama_stack_provider_trustyai_fms"


### PR DESCRIPTION
## Intro

[PR #2637](https://github.com/meta-llama/llama-stack/pull/2637) introduces a change in which external providers for llama stack can be configured via the module; it is expected that this module approach is going to be the recommended way of configuring remote providers going forward . Moreover, it is expected that the previous approach (via `providers.d`) will eventually be deprecated. 

This PR should ensure compatibility with the [PR #2637](https://github.com/meta-llama/llama-stack/pull/2637)

## Test plan

This was tested manually by starting up local llama distros with the following configuration files:

1. [module-way with dynamic shield registration](https://github.com/m-misiura/llama-stack-provider-trustyai-fms/blob/external_providers_from_module_fix_setter_runtimes/runtime_configurations/orchestrator_api_dynamic_module.yaml)

2. [module-way with static shield registration](https://github.com/m-misiura/llama-stack-provider-trustyai-fms/blob/external_providers_from_module_fix_setter_runtimes/runtime_configurations/orchestrator_api_static_module.yaml) 

3. [providers.d-way with dynamic shield registration](https://github.com/m-misiura/llama-stack-provider-trustyai-fms/blob/external_providers_from_module_fix_setter_runtimes/runtime_configurations/orchestrator_api_dynamic_providersd.yaml)

4. [provider.d-way with static shield registration](https://github.com/m-misiura/llama-stack-provider-trustyai-fms/blob/external_providers_from_module_fix_setter_runtimes/runtime_configurations/orchestrator_api_static_providersd.yaml)

### Dynamic registration illustration

You can configure the provider either using the `module` way

```yaml
version: '2'
image_name: trial
apis:
  - safety
  - shields

providers:
  safety:
    - provider_id: trustyai_fms
      provider_type: remote::trustyai_fms
      module: llama_stack_provider_trustyai_fms   
      config:
        orchestrator_url: ${env.FMS_ORCHESTRATOR_URL}
        shields: {}

server:
  port: 8321
  tls_certfile: null
  tls_keyfile: null

shields: []
```

or the `providers.d way`

```yaml
version: '2'
image_name: trial
apis:
  - safety
  - shields

providers:
  safety:
    - provider_id: trustyai_fms
      provider_type: remote::trustyai_fms
      config:
        orchestrator_url: ${env.FMS_ORCHESTRATOR_URL}
        shields: {}
           
server:
  port: 8321
  tls_certfile: null
  tls_keyfile: null
  
external_providers_dir: ./providers.d

shields: []
```

In either case, you should be able to:

- start the server, e.g. `llama stack run runtime_configurations/orchestrator_api_dynamic_module.yaml`

- dynamically register shields via the API, e.g
```
curl -X 'POST' \
"http://localhost:8321/v1/shields" \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-d '{
  "shield_id": "hap_shield",
  "provider_shield_id": "hap_shield",
  "provider_id": "trustyai_fms",
  "params": {
    "type": "content",
    "confidence_threshold": 0.5,
    "message_types": ["system"],
    "detectors": {
      "hap": {
        "detector_params": {}
      }
    }
  }
}'
{"identifier":"hap_shield","provider_resource_id":"hap_shield","provider_id":"trustyai_fms","type":"shield","owner":null,"source":"via_register_api","params":{"type":"content","confidence_threshold":0.5,"message_types":["system"],"detectors":{"hap":{"detector_params":{}}}}}
```

## Summary by Sourcery

Add compatibility with module-based provider configuration by updating provider specs, enhance shield store thread safety and overwrite prevention, and bump the package version.

Enhancements:
- Add an asyncio lock to SimpleShieldStore for thread-safe detector configuration registration
- Prevent overwriting an existing shield store by logging and ignoring subsequent assignments
- Include adapter_type "remote" and fully qualified config_class paths in ProviderSpec definitions for module configuration
- Bump package version to 0.1.5