### PR TITLE
Add run_moderation to the remote provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.2.0"
+version = "0.2.1"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+@pytest.mark.asyncio
+async def test_run_moderation_flagged():
+    from llama_stack_provider_trustyai_fms.detectors.base import DetectorProvider
+
+    provider = DetectorProvider(detectors={})
+    provider._get_shield_id_from_model = AsyncMock(return_value="test_shield")
+    provider._convert_input_to_messages = MagicMock(return_value=[
+        MagicMock(content="bad message"), MagicMock(content="good message")
+    ])
+    # Simulate shield_response with one flagged and one not
+    class FakeViolation:
+        violation_level = "error"
+        user_message = "violation"
+        metadata = {
+            "results": [
+                {"message_index": 0, "detection_type": "LABEL_1", "score": 0.99, "status": "violation"},
+                {"message_index": 1, "detection_type": None, "score": None, "status": "pass"},
+            ]
+        }
+    class FakeShieldResponse:
+        violation = FakeViolation()
+    provider.run_shield = AsyncMock(return_value=FakeShieldResponse())
+
+    result = await provider.run_moderation(["bad message", "good message"], "test_model")
+    assert len(result.results) == 2
+    assert result.results[0].flagged is True
+    assert result.results[1].flagged is False
+    assert result.results[0].user_message == "bad message"
+    assert result.results[1].user_message == "good message"
+
+@pytest.mark.asyncio
+async def test_run_moderation_error():
+    from llama_stack_provider_trustyai_fms.detectors.base import DetectorProvider
+
+    provider = DetectorProvider(detectors={})
+    provider._get_shield_id_from_model = AsyncMock(side_effect=Exception("fail"))
+    provider._convert_input_to_messages = MagicMock(return_value=[MagicMock(content="msg")])
+
+    result = await provider.run_moderation(["msg"], "test_model")
+    assert len(result.results) == 1
+    assert result.results[0].flagged is False
+    assert "fail" in result.results[0].metadata["error"]


### PR DESCRIPTION
## What does this PR do?

With the changes in upstream llama stack >= 0.2.18, there is a need to add the `run_moderation` method, else the provider will break (see this [PR](https://github.com/llamastack/llama-stack/pull/3098) and this [discussion](https://github.com/llamastack/llama-stack/issues/2367)

To ensure backward compatibility, e.g. with llama stack == 0.2.14, imports `ModerationObject` and `ModerationObjectResults` are put inside the try-except statement

## Test plan

I added some tests for the `run_moderation` using Mocks. I also tested manually against a live server

Here is a run_moderation response from an inline provider (codeshield)

```
url -X POST http://localhost:8321/v1/openai/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "input": ["You dotard, I really hate this", "My email is test@email.com", "This is a test message"],
    "model": "code-scanner"
  }' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:-100   587  100   449  100   138  11593   3563 --:--:-- --:--:-- --:--:-- 15447
{
  "id": "7cdca466-2ce5-4a16-93f3-840a0c6977f8",
  "model": "code-scanner",
  "results": [
    {
      "flagged": false,
      "categories": {},
      "category_applied_input_types": {},
      "category_scores": {},
      "user_message": null,
      "metadata": {}
    },
    {
      "flagged": false,
      "categories": {},
      "category_applied_input_types": {},
      "category_scores": {},
      "user_message": null,
      "metadata": {}
    },
    {
      "flagged": false,
      "categories": {},
      "category_applied_input_types": {},
      "category_scores": {},
      "user_message": null,
      "metadata": {}
    }
  ]
}
```

Here is a run_moderation response from the trustyai_fms provider

```
curl -X POST http://localhost:8321/v1/openai/v1/moderations \
  -H "Content-Type: application/json" \
  -d '{
    "input": ["You dotard, I really hate this", "My email is test@email.com", "This is a test message"],
    "model": "composite_shield"
  }' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:-100   142    0     0  100   142      0    687 --:--:-- --:--:-- --:-100  1668  100  1526  100   142   2788    259 --:--:-- --:--:-- --:--:--  3043
{
  "id": "862c7d2a-14a8-4587-8f30-aebc8b996233",
  "model": "composite_shield",
  "results": [
    {
      "flagged": true,
      "categories": {
        "LABEL_1": true
      },
      "category_applied_input_types": {
        "LABEL_1": [
          "text"
        ]
      },
      "category_scores": {
        "LABEL_1": 0.9750116467475892
      },
      "user_message": "You dotard, I really hate this",
      "metadata": {
        "message_index": 0,
        "text": "You dotard, I really hate this",
        "status": "violation",
        "score": 0.9750116467475892,
        "detection_type": "LABEL_1",
        "individual_detector_results": [
          {
            "detector_id": "hap",
            "status": "violation",
            "score": 0.9750116467475892,
            "detection_type": "LABEL_1"
          },
          {
            "detector_id": "regex",
            "status": "pass",
            "score": null,
            "detection_type": null
          }
        ]
      }
    },
    {
      "flagged": true,
      "categories": {
        "pii": true
      },
      "category_applied_input_types": {
        "pii": [
          "text"
        ]
      },
      "category_scores": {
        "pii": 1.0
      },
      "user_message": "My email is test@email.com",
      "metadata": {
        "message_index": 1,
        "text": "My email is test@email.com",
        "status": "violation",
        "score": 1.0,
        "detection_type": "pii",
        "individual_detector_results": [
          {
            "detector_id": "hap",
            "status": "pass",
            "score": null,
            "detection_type": null
          },
          {
            "detector_id": "regex",
            "status": "violation",
            "score": 1.0,
            "detection_type": "pii"
          }
        ]
      }
    },
    {
      "flagged": false,
      "categories": {},
      "category_applied_input_types": {},
      "category_scores": {},
      "user_message": "This is a test message",
      "metadata": {
        "message_index": 2,
        "text": "This is a test message",
        "status": "pass",
        "score": null,
        "detection_type": null,
        "individual_detector_results": [
          {
            "detector_id": "hap",
            "status": "pass",
            "score": null,
            "detection_type": null
          },
          {
            "detector_id": "regex",
            "status": "pass",
            "score": null,
            "detection_type": null
          }
        ]
      }
    }
  ]
}
```

In addition:

- there is also a testpypi module: https://test.pypi.org/project/llama-stack-provider-trustyai-fms/0.2.1/
- I also built an image to be used with the llama stack operator: `quay.io/rh-ee-mmisiura/lls:run_moderation`

## Summary by Sourcery

Enable moderation support in the trustyai_fms provider by implementing run_moderation with backward compatibility fallbacks and accompanying unit tests

New Features:
- Add run_moderation method to the remote provider to support content moderation using llama-stack shields

Enhancements:
- Log a warning when moderation support is unavailable on older llama-stack versions
- Introduce helper methods to map model names to shield IDs and convert input texts to message objects

Tests:
- Add unit tests for run_moderation covering flagged results, error handling, empty inputs, and single-string inputs

Chores:
- Bump package version to 0.2.1