### PR TITLE
DoNotMerge: Testing CI

### DIFF
--- a/run.yaml
+++ b/run.yaml
@@ -17,4 +17,4 @@ providers:
             detectors:
                 regex:
                   detector_params:
-                    regex: ["email", "ssn", "credit-card", "^verypersonal$"]
+                    regex: ["email"]


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove regex detector parameters from run.yaml for CI testing