### PR TITLE
Fix auth token propagation in dynamic shield creation

### DIFF
--- a/llama_stack_provider_trustyai_fms/detectors/base.py
+++ b/llama_stack_provider_trustyai_fms/detectors/base.py
@@ -723,52 +723,6 @@ class SimpleShieldStore(ShieldStore):
                 f"Shield store {self._store_id} initialized with {len(self._detector_configs)} configs"
             )
 
-        def _generate_params_for_shield(self, shield_id, config):
-            """Helper method to generate shield parameters from config"""
-            params = {}
-
-            # For content detectors with multiple sub-detectors
-            if hasattr(config, "detectors") and config.detectors:
-                detectors_config = {}
-                for det_id, det_config in config.detectors.items():
-                    det_params = {}
-                    if "detector_params" in det_config:
-                        det_params = det_config["detector_params"]
-                    detectors_config[det_id] = det_params
-                params["detectors"] = detectors_config
-
-            # For chat detectors with model parameters
-            elif hasattr(config, "detector_params") and config.detector_params:
-                if (
-                    hasattr(config.detector_params, "model_params")
-                    and config.detector_params.model_params
-                ):
-                    params["model_params"] = dict(config.detector_params.model_params)
-
-                # Add metadata fields
-                if (
-                    hasattr(config.detector_params, "metadata")
-                    and config.detector_params.metadata
-                ):
-                    if "model_params" not in params:
-                        params["model_params"] = {}
-                    # Add all metadata fields
-                    for key, value in config.detector_params.metadata.items():
-                        params["model_params"][key] = value
-
-            # Add common shield information
-            params.update(
-                {
-                    "display_name": f"{shield_id} Shield",
-                    "display_description": f"Safety shield for {shield_id}",
-                    "detector_type": "content" if not config.is_chat else "chat",
-                    "message_types": list(config.message_types),
-                    "confidence_threshold": config.confidence_threshold,
-                }
-            )
-
-            return params
-
     async def get_shield(self, identifier: str) -> Shield:
         """Get or create shield by identifier"""
         await self.initialize()
@@ -896,7 +850,7 @@ class SimpleShieldStore(ShieldStore):
                 # URL configuration
                 orchestrator_url=orchestrator_url,
                 detector_url=None,  # Will be set if needed
-                auth_token=None,
+                auth_token=params.get("auth_token"),
                 verify_ssl=params.get("verify_ssl", True),
                 ssl_cert_path=params.get("ssl_cert_path"),
                 ssl_client_cert=params.get("ssl_client_cert"),
@@ -918,7 +872,7 @@ class SimpleShieldStore(ShieldStore):
                 # URL configuration
                 orchestrator_url=orchestrator_url,
                 detector_url=None,
-                auth_token=None,
+                auth_token=params.get("auth_token"),
                 verify_ssl=params.get("verify_ssl", True),
                 ssl_cert_path=params.get("ssl_cert_path"),
                 ssl_client_cert=params.get("ssl_client_cert"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llama-stack-provider-trustyai-fms"
-version = "0.2.1"
+version = "0.2.2"
 description = "Remote safety provider for Llama Stack integrating FMS Guardrails Orchestrator and community detectors"
 authors = [
     {name = "GitHub: m-misiura"}


### PR DESCRIPTION
## Problem

This PR deals with the following [RHOAIENG-34050](https://issues.redhat.com/browse/RHOAIENG-34050) and addresses a bug, where dynamic shields created via API were not receiving authentication tokens, causing requests to fail with OAuth login pages instead of proper API responses. 

## Solution
- Added `auth_token=params.get("auth_token")` to both `ContentDetectorConfig` and `ChatDetectorConfig` creation in `create_dynamic_shield()` method
- This ensures auth tokens from shield registration API calls are properly propagated to the detector configuration
- Maintains backward compatibility by defaulting to `None` when no token is provided

## Test plan

The updated python package has been uploaded to [TestPyPI](https://test.pypi.org/project/llama-stack-provider-trustyai-fms/0.2.2/) and can be 
```
pip install -i https://test.pypi.org/simple/ llama-stack-provider-trustyai-fms==0.2.2
```

1. Deploy authenticated detector and orchestrator, e.g. 
```
apiVersion: trustyai.opendatahub.io/v1alpha1
kind: GuardrailsOrchestrator
metadata:
  name: guardrails-orchestrator
  annotations:
    security.opendatahub.io/enable-auth: 'true' 
spec:
  autoConfig:
      detectorServiceLabelToMatch: trustyai/guardrails
      inferenceServiceToGuardrail: llm
  enableBuiltInDetectors: true
  enableGuardrailsGateway: false
  logLevel: DEBUG
  replicas: 1
```

```
apiVersion: v1
kind: Service
metadata:
  name: minio-storage-guardrail-detectors
spec:
  ports:
    - name: minio-client-port
      port: 9000
      protocol: TCP
      targetPort: 9000
  selector:
    app: minio-storage-guardrail-detectors
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: minio-storage-guardrail-detectors-claim
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  # storageClassName: gp3-csi
  resources:
    requests:
      storage: 10Gi
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: minio-storage-guardrail-detectors # <--- change this
labels:
    app: minio-storage-guardrail-detectors # <--- change this to match label on the pod
spec:
  replicas: 1
  selector:
    matchLabels:
      app: minio-storage-guardrail-detectors  # <--- change this to match label on the pod
  template: # => from here down copy and paste the pods metadata: and spec: sections
    metadata:
      labels:
        app: minio-storage-guardrail-detectors
        maistra.io/expose-route: 'true'
      name: minio-storage-guardrail-detectors
    spec:
      volumes:
      - name: model-volume
        persistentVolumeClaim:
          claimName: minio-storage-guardrail-detectors-claim
      initContainers:
        - name: download-model
          image: quay.io/trustyai_testing/llm-downloader:latest
          securityContext:
            fsGroup: 1001
          command:
            - bash
            - -c
            - |
              models=(
                # unitary/toxic-bert
                ibm-granite/granite-guardian-hap-38m
                # protectai/deberta-v3-base-prompt-injection-v2
              )
              echo "Starting download"
              mkdir /mnt/models/llms/
              for model in "${models[@]}"; do
                echo "Downloading $model"
                /tmp/venv/bin/huggingface-cli download $model --local-dir /mnt/models/huggingface/$(basename $model)
              done

              echo "Done!"
          resources:
            limits:
              memory: "2Gi"
              cpu: "1"
          volumeMounts:
            - mountPath: "/mnt/models/"
              name: model-volume
      containers:
        - args:
            - server
            - /models
          env:
            - name: MINIO_ACCESS_KEY
              value:  THEACCESSKEY
            - name: MINIO_SECRET_KEY
              value: THESECRETKEY
          image: quay.io/trustyai/modelmesh-minio-examples:latest
          name: minio
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            seccompProfile:
              type: RuntimeDefault
          volumeMounts:
            - mountPath: "/models/"
              name: model-volume
---
apiVersion: v1
kind: Secret
metadata:
  name: aws-connection-minio-data-connection-detector-models
  labels:
    opendatahub.io/dashboard: 'true'
    opendatahub.io/managed: 'true'
  annotations:
    opendatahub.io/connection-type: s3
    openshift.io/display-name: Minio Data Connection - Guardrail Detector Models
data: # these are just base64 encodings
  AWS_ACCESS_KEY_ID: VEhFQUNDRVNTS0VZ #THEACCESSKEY
  AWS_DEFAULT_REGION: dXMtc291dGg= #us-south
  AWS_S3_BUCKET: aHVnZ2luZ2ZhY2U= #huggingface
  AWS_S3_ENDPOINT: aHR0cDovL21pbmlvLXN0b3JhZ2UtZ3VhcmRyYWlsLWRldGVjdG9yczo5MDAw #http://minio-storage-guardrail-detectors:9000
  AWS_SECRET_ACCESS_KEY: VEhFU0VDUkVUS0VZ #THESECRETKEY
type: Opaque%

```

```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  name: guardrails-detector-runtime-hap
  annotations:
    openshift.io/display-name: Guardrails Detector ServingRuntime for KServe
    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
  labels:
    opendatahub.io/dashboard: 'true'
    trustyai/guardrails: 'true'
spec:
  annotations:
    prometheus.io/port: '8080'
    prometheus.io/path: '/metrics'
  multiModel: false
  supportedModelFormats:
    - autoSelect: true
      name: guardrails-detector-huggingface
  containers:
    - name: kserve-container
      image: quay.io/rh-ee-mmisiura/hf-detector:latest 
      command:
        - uvicorn
        - app:app
      args:
        - "--workers"
        - "4"
        - "--host"
        - "0.0.0.0"
        - "--port"
        - "8000"
        - "--log-config"
        - "/common/log_conf.yaml"
      env:
        - name: MODEL_DIR
          value: /mnt/models
        - name: HF_HOME
          value: /tmp/hf_home
      ports:
        - containerPort: 8000
          protocol: TCP
---
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: ibm-hap-38m-detector
  labels:
    opendatahub.io/dashboard: 'true'
    trustyai/guardrails: 'true'
  annotations:
    openshift.io/display-name: ibm-hap-38m-detector
    serving.knative.openshift.io/enablePassthrough: 'true'
    sidecar.istio.io/inject: 'true'
    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
    serving.kserve.io/deploymentMode: RawDeployment
    security.opendatahub.io/enable-auth: 'true'
spec:
  predictor:
    maxReplicas: 1
    minReplicas: 1
    model:
      modelFormat:
        name: guardrails-detector-huggingface
      name: ''
      runtime: guardrails-detector-runtime-hap
      storage:
        key: aws-connection-minio-data-connection-detector-models
        path: granite-guardian-hap-38m
      resources:
        limits:
          cpu: '1'
          memory: 2Gi
          nvidia.com/gpu: '0'
        requests:
          cpu: '1'
          memory: 2Gi
          nvidia.com/gpu: '0'
---
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  name: hap-detector-route
spec:
  to:
    kind: Service
    name: ibm-hap-38m-detector-predictor
  port:
    targetPort: https
  tls:
    termination: reencrypt
```

2. Deploy lls distro on openshift with a custom image: `quay.io/rh-ee-mmisiura/lls:fms_oauth`; ensure there is a also a VLLM_URL specified in the `env`

3. Expose the lls route
```
oc expose service llamastack-custom-distribution-service --name=lls-route
LLS_ROUTE=$(oc get route lls-route -o jsonpath='{.spec.host}')
```

4. Get the authentication token
```
TOKEN=$(oc whoami -t)
```

5. Dynamically register the composite shield
```
curl -X 'POST' \
"http://$LLS_ROUTE/v1/shields" \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-d '{
  "shield_id": "secure_shield",
  "provider_shield_id": "secure_shield",
  "provider_id": "trustyai_fms",
  "params": {
    "type": "content",
    "confidence_threshold": 0.5,
    "message_types": ["system"],
    "auth_token": "'"$TOKEN"'",
    "verify_ssl": true,
    "detectors": {
      "ibm-hap-38m-detector": {
        "detector_params": {}
      },
      "built-in-detector": {
        "detector_params": {
          "regex": ["email", "ssn", "credit-card", "^hello$"]
        }
      }
    }
  }
}'
```

6. Trigger the regex detector
```
curl -X POST "http://$LLS_ROUTE/v1/safety/run-shield" \
-H "Content-Type: application/json" \
-d '{
  "shield_id": "secure_shield",
  "messages": [
    {
      "content": "My email is test@example.com",
      "role": "system"
    }
  ]
}' | jq '.'
```
which should yield
```
{
  "violation": {
    "violation_level": "error",
    "user_message": "Content violation detected by shield secure_shield (confidence: 1.00, 1/1 processed messages violated)",
    "metadata": {
      "status": "violation",
      "shield_id": "secure_shield",
      "confidence_threshold": 0.5,
      "summary": {
        "total_messages": 1,
        "processed_messages": 1,
        "skipped_messages": 0,
        "messages_with_violations": 1,
        "messages_passed": 0,
        "message_fail_rate": 1.0,
        "message_pass_rate": 0.0,
        "total_detections": 1,
        "detector_breakdown": {
          "active_detectors": 2,
          "total_checks_performed": 2,
          "total_violations_found": 1,
          "violations_per_message": 1.0
        }
      },
      "results": [
        {
          "message_index": 0,
          "text": "My email is test@example.com",
          "status": "violation",
          "score": 1.0,
          "detection_type": "pii",
          "individual_detector_results": [
            {
              "detector_id": "ibm-hap-38m-detector",
              "status": "pass",
              "score": null,
              "detection_type": null
            },
            {
              "detector_id": "built-in-detector",
              "status": "violation",
              "score": 1.0,
              "detection_type": "pii"
            }
          ]
        }
      ]
    }
  }
}
```

7. Trigger the hap detector
```
curl -X POST "http://$LLS_ROUTE/v1/safety/run-shield" \
-H "Content-Type: application/json" \
-d '{
  "shield_id": "secure_shield",
  "messages": [
    {
      "content": "You dotard, I really hate this",
      "role": "system"
    }
  ]
}' | jq '.'
```
which should yield
```
{
  "violation": {
    "violation_level": "error",
    "user_message": "Content violation detected by shield secure_shield (confidence: 0.98, 1/1 processed messages violated)",
    "metadata": {
      "status": "violation",
      "shield_id": "secure_shield",
      "confidence_threshold": 0.5,
      "summary": {
        "total_messages": 1,
        "processed_messages": 1,
        "skipped_messages": 0,
        "messages_with_violations": 1,
        "messages_passed": 0,
        "message_fail_rate": 1.0,
        "message_pass_rate": 0.0,
        "total_detections": 1,
        "detector_breakdown": {
          "active_detectors": 2,
          "total_checks_performed": 2,
          "total_violations_found": 1,
          "violations_per_message": 1.0
        }
      },
      "results": [
        {
          "message_index": 0,
          "text": "You dotard, I really hate this",
          "status": "violation",
          "score": 0.9750116467475892,
          "detection_type": "LABEL_1",
          "individual_detector_results": [
            {
              "detector_id": "ibm-hap-38m-detector",
              "status": "violation",
              "score": 0.9750116467475892,
              "detection_type": "LABEL_1"
            },
            {
              "detector_id": "built-in-detector",
              "status": "pass",
              "score": null,
              "detection_type": null
            }
          ]
        }
      ]
    }
  }
}
```

## Summary by Sourcery

Ensure auth tokens are correctly passed when creating dynamic shields and clean up unused code

Bug Fixes:
- Propagate auth_token to ContentDetectorConfig creation in create_dynamic_shield
- Propagate auth_token to ChatDetectorConfig creation in create_dynamic_shield

Enhancements:
- Remove unused _generate_params_for_shield helper method

Build:
- Bump package version to 0.2.2