### PR TITLE
Scope pre commit hooks rather than running them on all files

### DIFF
--- a/.github/workflows/.pre-commit.yaml
+++ b/.github/workflows/.pre-commit.yaml
@@ -26,6 +26,4 @@ jobs:
           pip install -e ".[test]"
 
       - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: --all-files
+        uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,31 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.0
+    rev: v0.13.1
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
+        types_or: [python, pyi]
+        files: ^(llama_stack_provider_trustyai_fms/|tests/).*\.(py)$
       - id: ruff-format
+        types_or: [python, pyi]
+        files: ^(llama_stack_provider_trustyai_fms/|tests/).*\.(py)$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        files: \.(py|ipynb|md)$
       - id: end-of-file-fixer
+        files: \.(py|ipynb|md)$
       - id: check-yaml
         args: [--allow-multiple-documents]
+        files: \.ya?ml$
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: check-case-conflict
       - id: check-docstring-first
+        files: ^(llama_stack_provider_trustyai_fms/|tests/).*\.(py)$
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Description

At present, the pre-commit hook runs on all files (.py, .md and .yaml) within the repo; I think it would make sense for some hooks, particularly the python-specific ones to run only on python files

Additionally, I also updated the versions of some of the pre-commit-hooks

Once this is merged, I will run a pre-commit to fix some of the files :)

## Summary by Sourcery

Refine pre-commit hook configuration by scoping hooks to relevant file types and bumping hook versions, and update CI step to use the modern pre-commit action without the `--all-files` flag.

Enhancements:
- Restrict python-specific ruff hooks to .py/.pyi files in the source and tests directories
- Limit trailing-whitespace and end-of-file-fixer hooks to .py, .ipynb, and .md files
- Confine check-yaml to .yml/.yaml files and check-docstring-first to python files in source and tests
- Update ruff-pre-commit rev to v0.13.1 and pre-commit-hooks rev to v6.0.0

CI:
- Bump GitHub pre-commit action to v3.0.1 and remove the `--all-files` argument