### PR TITLE
Replace non-test assertions

### DIFF
--- a/llama_stack_provider_trustyai_fms/detectors/base.py
+++ b/llama_stack_provider_trustyai_fms/detectors/base.py
@@ -1557,9 +1557,8 @@ class DetectorProvider(Safety, Shields):
                         continue
 
                     # Extract data
-                    assert isinstance(result, dict), (
-                        "Expected result to be a dictionary"
-                    )
+                    if not isinstance(result, dict):
+                        raise TypeError("Expected result to be a dictionary")
                     message_results.append(result["result"])
 
                     # Update aggregate metrics
@@ -1652,9 +1651,8 @@ class DetectorProvider(Safety, Shields):
                         continue
 
                     # Extract data
-                    assert isinstance(result, dict), (
-                        "Expected result to be a dictionary"
-                    )
+                    if not isinstance(result, dict):
+                        raise TypeError("Expected result to be a dictionary")
                     message_results.append(result["result"])
 
                     # Update aggregate metrics


### PR DESCRIPTION
This PR addresses Bandit security warnings by replacing all non-test assert statements in non-test ode with explicit runtime type checks and exceptions.

## Summary by Sourcery

Enhancements:
- Replace non-test assert statements with explicit runtime type checks that raise TypeError