### PR TITLE
Upgrade Trivy action version in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
           python -m pip install -e ".[dev]"
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -40,7 +40,7 @@ jobs:
           exit-code: '0'
 
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
Updated Trivy action version to v0.35.0 for vulnerability scanning.

## Summary by Sourcery

CI:
- Update the Trivy action in the security workflow from v0.28.0 to a pinned commit corresponding to v0.35.0 for both general and high/critical vulnerability scans.