### PR TITLE
Mark project as no longer in active development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Note: This project is in maintenance mode.** It is no longer under active development. Bug fixes and security patches may still be accepted, but no new features are planned.
+
 # `trustyai_fms`: out-of-tree remote safety provider for llama stack
 
 This repo implements [FMS Guardrails Orchestrator](https://github.com/foundation-model-stack/fms-guardrails-orchestrator) together with community detectors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "fastapi",
     "opentelemetry-api",


### PR DESCRIPTION
As llama stack is removing safety api, this provider will no longer be applicable

## Summary by Sourcery

Mark the project as inactive and clarify its maintenance-only status in packaging metadata and user-facing documentation.

Build:
- Set the package classifier to indicate the project is inactive and no longer under active development.

Documentation:
- Add a prominent notice to the README indicating the project is in maintenance mode with no new features planned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a maintenance-mode notice to the README informing users that the project is no longer under active development, with only critical bug and security fixes being accepted.

* **Chores**
  * Updated project metadata to indicate inactive development status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->